### PR TITLE
Support specific aws credentials during dynamoDB initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.swx
 .DS_Store
 .bundle
+.idea
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In your `spec_helper.rb` setup quarantine and rspec-retry gem. Click [rspec-retr
 require 'quarantine'
 require 'rspec-retry'
 
-Quarantine.bind({database: :dynamodb, aws_region: 'us-west-1'})
+Quarantine.bind({database: :dynamodb, aws_region: 'us-west-1'}) # Also accepts aws_credentials to override the standard AWS credential chain
 
 RSpec.configure do |config|
 
@@ -140,7 +140,8 @@ CI="1" BRANCH="master" rspec
 
 #### Why is dynamodb failing to connect?
 
-The AWS client loads credentials from the following locations:
+The AWS client loads credentials from the following locations (in order of precedence):
+- The optional `aws_credentials` parameter passed into `Quarantine.bind`
 - `ENV['AWS_ACCESS_KEY_ID']` and `ENV['AWS_SECRET_ACCESS_KEY']`
 - `Aws.config[:credentials]`
 - The shared credentials ini file at `~/.aws/credentials`

--- a/lib/quarantine/databases/dynamo_db.rb
+++ b/lib/quarantine/databases/dynamo_db.rb
@@ -7,8 +7,11 @@ class Quarantine
     class DynamoDB < Base
       attr_accessor :dynamodb
 
-      def initialize(aws_region: 'us-west-1', **_additional_arguments)
-        @dynamodb = Aws::DynamoDB::Client.new({ region: aws_region })
+      def initialize(aws_region: 'us-west-1', aws_credentials: nil, **_additional_arguments)
+        options = { region: aws_region }
+        options[:credentials] = aws_credentials if aws_credentials
+
+        @dynamodb = Aws::DynamoDB::Client.new(options)
       end
 
       def scan(table_name)

--- a/spec/quarantine/databases/dynamo_db_spec.rb
+++ b/spec/quarantine/databases/dynamo_db_spec.rb
@@ -15,6 +15,15 @@ describe Quarantine::Databases::DynamoDB do
       expect(database.dynamodb).to be_a(Aws::DynamoDB::Client)
       expect(database.dynamodb.config.region).to eq('us-east-2')
     end
+
+    it 'aws credentials to fake credentials' do
+      fake_creds = Aws::Credentials.new('fake', 'creds')
+      database = Quarantine::Databases::DynamoDB.new({ aws_credentials: fake_creds })
+
+      expect(database.dynamodb).to be_a(Aws::DynamoDB::Client)
+      expect(database.dynamodb.config.region).to eq('us-west-1')
+      expect(database.dynamodb.config.credentials).to eq(fake_creds)
+    end
   end
 
   context '#scan' do


### PR DESCRIPTION
Allow an `aws_credentials` parameter to be passed down, to override the standard AWS credential chain.