### PR TITLE
Filter out tests that are duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.6
+  Update DynamoDB batch_write_item implementation to check for duplicates based on different keys before uploading
+
 ### 1.0.5
   Add aws_credentials argument during dynamodb initialization to override the AWS SDK credential chain
 

--- a/lib/quarantine/databases/dynamo_db.rb
+++ b/lib/quarantine/databases/dynamo_db.rb
@@ -16,7 +16,7 @@ class Quarantine
 
       def scan(table_name)
         begin
-          result = dynamodb.scan({ table_name: table_name })
+          result = dynamodb.scan(table_name: table_name)
         rescue Aws::DynamoDB::Errors::ServiceError
           raise Quarantine::DatabaseError
         end
@@ -24,16 +24,16 @@ class Quarantine
         result&.items
       end
 
-      def batch_write_item(table_name, items, additional_attributes = {}, dedup_keys=["id", "full_description"])
+      def batch_write_item(table_name, items, additional_attributes = {}, dedup_keys = %w[id full_description])
         return if items.empty?
 
         # item_a is a duplicate of item_b if all values for each dedup_key in both item_a and item_b match
-        is_a_duplicate = -> (item_a, item_b) { dedup_keys.all? { |key| item_a[key] == item_b[key] } }
+        is_a_duplicate = ->(item_a, item_b) { dedup_keys.all? { |key| item_a[key] == item_b[key] } }
 
         scanned_items = scan(table_name)
 
         deduped_items = items.reject do |item|
-          scanned_items.any?  do |scanned_item|
+          scanned_items.any? do |scanned_item|
             is_a_duplicate.call(item.to_string_hash, scanned_item)
           end
         end
@@ -41,7 +41,7 @@ class Quarantine
         return if deduped_items.empty?
 
         dynamodb.batch_write_item(
-          { request_items: {
+          request_items: {
             table_name => deduped_items.map do |item|
               {
                 put_request: {
@@ -49,7 +49,7 @@ class Quarantine
                 }
               }
             end
-          } }
+          }
         )
       rescue Aws::DynamoDB::Errors::ServiceError
         raise Quarantine::DatabaseError
@@ -57,11 +57,9 @@ class Quarantine
 
       def delete_item(table_name, keys)
         dynamodb.delete_item(
-          {
-            table_name: table_name,
-            key: {
-              **keys
-            }
+          table_name: table_name,
+          key: {
+            **keys
           }
         )
       rescue Aws::DynamoDB::Errors::ServiceError

--- a/lib/quarantine/test.rb
+++ b/lib/quarantine/test.rb
@@ -20,5 +20,14 @@ class Quarantine
         build_number: build_number
       }
     end
+
+    def to_string_hash
+      {
+        "id" => id,
+        "full_description" => full_description,
+        "location" => location,
+        "build_number" => build_number
+      }
+    end
   end
 end

--- a/lib/quarantine/test.rb
+++ b/lib/quarantine/test.rb
@@ -23,10 +23,10 @@ class Quarantine
 
     def to_string_hash
       {
-        "id" => id,
-        "full_description" => full_description,
-        "location" => location,
-        "build_number" => build_number
+        'id' => id,
+        'full_description' => full_description,
+        'location' => location,
+        'build_number' => build_number
       }
     end
   end

--- a/lib/quarantine/version.rb
+++ b/lib/quarantine/version.rb
@@ -1,3 +1,3 @@
 class Quarantine
-  VERSION = '1.0.5'.freeze
+  VERSION = '1.0.6'.freeze
 end


### PR DESCRIPTION
In DynamoDB land, two items are duplicates iff their partition key and sort key are the same.

In Quarantine land, two tests could be considered a duplicate if the partition keys (`id`) are the same, but sort keys (`build_number`) are different.

This PR allows you to pass in `dedup_keys` into `batch_write_items`. Two `Quarantine::Test` instances will be considered duplicates if all the values for one's `dedup_keys` are equal to all the values for the other's `dedup_keys`. 