### PR TITLE
Fix local test example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ require "spec_helper"
 
 describe Quarantine do
   it "this test should flake 33% of the time" do
-    Random.rand(3).to eq(3)
+    expect(Random.rand(3)).to eq(1)
   end
 end
 ```
@@ -160,3 +160,7 @@ The AWS client loads credentials from the following locations (in order of prece
 To get AWS credentials, please contact your AWS administrator to get access to dynamodb and create your credentials through IAM.
 
 More detailed information can be found: [AWS documentation](https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html)
+
+#### Why is `example.clear_exception` failing locally?
+
+ `example.clear_exception` is an attribute added through `rspec_retry`. Make sure `rspec-retry` has been installed and configured.


### PR DESCRIPTION
The local test example had invalid RSpec syntax. It also looks like
`Random.rand(3)` won't return `3` 33% of the time (the result gets
converted to an integer so it's always (0, 1, or 2 unless the random
number was _exactly_ 3.0) so it gets adjusted to be 1 to allow the
example to be more easily testable.