### PR TITLE
Make database connection configurable via RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ In your `spec_helper.rb` setup quarantine and rspec-retry gem. Click [rspec-retr
 require 'quarantine'
 require 'rspec-retry'
 
-Quarantine.bind({database: :dynamodb, aws_region: 'us-west-1'}) # Also accepts aws_credentials to override the standard AWS credential chain
+Quarantine.bind_rspec
 
 RSpec.configure do |config|
+  # Also accepts `credentials` to override the standard AWS credential chain
+  config.quarantine_database = {type: :dynamodb, region: 'us-west-1'}
 
   config.around(:each) do |ex|
     ex.run_with_retry(retry: 3)
@@ -54,7 +56,7 @@ Consider wrapping `Quarantine.bind` in if statements so local flaky tests don't 
 
 ```rb
 if ENV[CI] && ENV[BRANCH] == "master"
-  Quarantine.bind({database: :dynamodb, aws_region: 'us-west-1'})
+  Quarantine.bind_rspec
 end
 ```
 
@@ -63,7 +65,7 @@ Setup tables in AWS DynamoDB to support pulling and uploading quarantined tests
 bundle exec quarantine_dynamodb -h    # see all options
 
 bundle exec quarantine_dynamodb \     # create the tables in us-west-1 in aws dynamodb
-  --aws_region us-west-1              # with "quarantine_list" and "master_failed_tests"
+  --region us-west-1                  # with "quarantine_list" and "master_failed_tests"
                                       # table names
 ```
 
@@ -141,7 +143,7 @@ CI="1" BRANCH="master" rspec
 #### Why is dynamodb failing to connect?
 
 The AWS client loads credentials from the following locations (in order of precedence):
-- The optional `aws_credentials` parameter passed into `Quarantine.bind`
+- The optional `credentials` field in `RSpec.configuration.quarantine_database`
 - `ENV['AWS_ACCESS_KEY_ID']` and `ENV['AWS_SECRET_ACCESS_KEY']`
 - `Aws.config[:credentials]`
 - The shared credentials ini file at `~/.aws/credentials`

--- a/lib/quarantine.rb
+++ b/lib/quarantine.rb
@@ -19,7 +19,8 @@ module RSpec
 end
 
 class Quarantine
-  attr_reader :options, :quarantine_map, :failed_tests, :flaky_tests, :duplicate_tests, :buildkite_build_number, :summary
+  attr_reader :options, :quarantine_map, :failed_tests, :flaky_tests, :duplicate_tests, :buildkite_build_number,
+              :summary
 
   def self.bind_rspec
     RSpecAdapter.bind_rspec
@@ -38,11 +39,11 @@ class Quarantine
     database_options = options[:database].dup
     type = database_options.delete(:type)
     @database ||= case type
-    when :dynamodb
-      Quarantine::Databases::DynamoDB.new(database_options)
-    else
-      raise Quarantine::UnsupportedDatabaseError.new("Quarantine does not support database type: #{type.inspect}")
-    end
+                  when :dynamodb
+                    Quarantine::Databases::DynamoDB.new(database_options)
+                  else
+                    raise Quarantine::UnsupportedDatabaseError.new("Quarantine does not support database type: #{type.inspect}")
+                  end
   end
 
   # Scans the quarantine_list from the database and store the individual tests in quarantine_map

--- a/lib/quarantine.rb
+++ b/lib/quarantine.rb
@@ -38,12 +38,13 @@ class Quarantine
   def database
     database_options = options[:database].dup
     type = database_options.delete(:type)
-    @database ||= case type
-                  when :dynamodb
-                    Quarantine::Databases::DynamoDB.new(database_options)
-                  else
-                    raise Quarantine::UnsupportedDatabaseError.new("Quarantine does not support database type: #{type.inspect}")
-                  end
+    @database ||= \
+      case type
+      when :dynamodb
+        Quarantine::Databases::DynamoDB.new(database_options)
+      else
+        raise Quarantine::UnsupportedDatabaseError.new("Quarantine does not support database type: #{type.inspect}")
+      end
   end
 
   # Scans the quarantine_list from the database and store the individual tests in quarantine_map

--- a/lib/quarantine/cli.rb
+++ b/lib/quarantine/cli.rb
@@ -18,8 +18,8 @@ class Quarantine
       OptionParser.new do |parser|
         parser.banner = 'Usage: quarantine_dynamodb [options]'
 
-        parser.on('-rREGION', '--aws_region=REGION', String, 'Specify the aws region for DynamoDB') do |aws_region|
-          options[:aws_region] = aws_region
+        parser.on('-rREGION', '--region=REGION', String, 'Specify the aws region for DynamoDB') do |region|
+          options[:region] = region
         end
 
         parser.on(
@@ -46,7 +46,7 @@ class Quarantine
         end
       end.parse!
 
-      if options[:aws_region].nil?
+      if options[:region].nil?
         error_msg = 'Failed to specify the required aws region with -r option'.freeze
         warn error_msg
         raise ArgumentError.new(error_msg)
@@ -55,7 +55,7 @@ class Quarantine
 
     # TODO: eventually move to a separate file & create_table by db type when my db adapters
     def create_tables
-      dynamodb = Quarantine::Databases::DynamoDB.new(options)
+      dynamodb = Quarantine::Databases::DynamoDB.new(region: options[:region])
 
       attributes = [
         { attribute_name: 'id', attribute_type: 'S', key_type: 'HASH' },

--- a/lib/quarantine/databases/dynamo_db.rb
+++ b/lib/quarantine/databases/dynamo_db.rb
@@ -7,10 +7,7 @@ class Quarantine
     class DynamoDB < Base
       attr_accessor :dynamodb
 
-      def initialize(aws_region: 'us-west-1', aws_credentials: nil, **_additional_arguments)
-        options = { region: aws_region }
-        options[:credentials] = aws_credentials if aws_credentials
-
+      def initialize(options)
         @dynamodb = Aws::DynamoDB::Client.new(options)
       end
 

--- a/lib/quarantine/rspec_adapter.rb
+++ b/lib/quarantine/rspec_adapter.rb
@@ -1,4 +1,4 @@
-module Quarantine
+class Quarantine
   module RSpecAdapter
     # Purpose: create an instance of Quarantine which contains information
     #          about the test suite (ie. quarantined tests) and binds RSpec configurations
@@ -45,7 +45,8 @@ module Quarantine
     def self.bind_quarantine_checker
       ::RSpec.configure do |config|
         config.after(:each) do |example|
-          if RSpec.configuration.skip_quarantined_tests && Quarantine::RSpecAdapter.quarantine.test_quarantined?(example)
+          if RSpec.configuration.skip_quarantined_tests \
+            && Quarantine::RSpecAdapter.quarantine.test_quarantined?(example)
             Quarantine::RSpecAdapter.quarantine.pass_flaky_test(example)
           end
         end

--- a/lib/quarantine/rspec_adapter.rb
+++ b/lib/quarantine/rspec_adapter.rb
@@ -1,21 +1,29 @@
-module RSpecAdapter
+module Quarantine::RSpecAdapter
   # Purpose: create an instance of Quarantine which contains information
   #          about the test suite (ie. quarantined tests) and binds RSpec configurations
   #          and hooks onto the global RSpec class
-  def bind(options = {})
-    quarantine = Quarantine.new(options)
+  def self.bind_rspec
     bind_rspec_configurations
-    bind_quarantine_list(quarantine)
-    bind_quarantine_checker(quarantine)
-    bind_quarantine_record_tests(quarantine)
-    bind_logger(quarantine)
+    bind_quarantine_list
+    bind_quarantine_checker
+    bind_quarantine_record_tests
+    bind_logger
+  end
+
+  def self.quarantine
+    @quarantine ||= Quarantine.new(
+      database: RSpec.configuration.quarantine_database,
+      list_table: RSpec.configuration.quarantine_list_table,
+      failed_tests_table: RSpec.configuration.quarantine_failed_tests_table,
+    )
   end
 
   private
 
   # Purpose: binds rspec configuration variables
-  def bind_rspec_configurations
+  def self.bind_rspec_configurations
     ::RSpec.configure do |config|
+      config.add_setting(:quarantine_database, default: {type: :dynamodb, region: 'us-west-1'})
       config.add_setting(:quarantine_list_table, { default: 'quarantine_list' })
       config.add_setting(:quarantine_failed_tests_table, { default: 'master_failed_tests' })
       config.add_setting(:skip_quarantined_tests, { default: true })
@@ -26,61 +34,61 @@ module RSpecAdapter
   end
 
   # Purpose: binds quarantine to fetch the quarantine_list from dynamodb in the before suite
-  def bind_quarantine_list(quarantine)
+  def self.bind_quarantine_list
     ::RSpec.configure do |config|
       config.before(:suite) do
-        quarantine.fetch_quarantine_list
+        Quarantine::RSpecAdapter.quarantine.fetch_quarantine_list
       end
     end
   end
 
   # Purpose: binds quarantine to skip and pass tests that have been quarantined in the after suite
-  def bind_quarantine_checker(quarantine)
+  def self.bind_quarantine_checker
     ::RSpec.configure do |config|
       config.after(:each) do |example|
-        if RSpec.configuration.skip_quarantined_tests && quarantine.test_quarantined?(example)
-          quarantine.pass_flaky_test(example)
+        if RSpec.configuration.skip_quarantined_tests && Quarantine::RSpecAdapter.quarantine.test_quarantined?(example)
+          Quarantine::RSpecAdapter.quarantine.pass_flaky_test(example)
         end
       end
     end
   end
 
   # Purpose: binds quarantine to record failed and flaky tests
-  def bind_quarantine_record_tests(quarantine)
+  def self.bind_quarantine_record_tests
     ::RSpec.configure do |config|
       config.after(:each) do |example|
         metadata = example.metadata
 
         # will record the failed test if is not quarantined and it is on it's final retry from the rspec-retry gem
-        quarantine.record_failed_test(example) if
+        Quarantine::RSpecAdapter.quarantine.record_failed_test(example) if
           RSpec.configuration.quarantine_record_failed_tests &&
-          !quarantine.test_quarantined?(example) &&
+          !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
           metadata[:retry_attempts] + 1 == metadata[:retry] && example.exception
 
         # will record the flaky test if is not quarantined and it failed the first run but passed a subsequent run;
         # optionally, the upstream RSpec configuration could define an after hook that marks an example as flaky in
         # the example's metadata
-        quarantine.record_flaky_test(example) if
+        Quarantine::RSpecAdapter.quarantine.record_flaky_test(example) if
           RSpec.configuration.quarantine_record_flaky_tests &&
-          !quarantine.test_quarantined?(example) &&
+          !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
           (metadata[:retry_attempts] > 0 && example.exception.nil?) || metadata[:flaky]
       end
     end
 
     ::RSpec.configure do |config|
       config.after(:suite) do
-        quarantine.upload_tests(:failed) if RSpec.configuration.quarantine_record_failed_tests
+        Quarantine::RSpecAdapter.quarantine.upload_tests(:failed) if RSpec.configuration.quarantine_record_failed_tests
 
-        quarantine.upload_tests(:flaky) if RSpec.configuration.quarantine_record_flaky_tests
+        Quarantine::RSpecAdapter.quarantine.upload_tests(:flaky) if RSpec.configuration.quarantine_record_flaky_tests
       end
     end
   end
 
   # Purpose: binds quarantine logger to output test to RSpec formatter messages
-  def bind_logger(quarantine)
+  def self.bind_logger
     ::RSpec.configure do |config|
       config.after(:suite) do
-        RSpec.configuration.reporter.message(quarantine.summary) if RSpec.configuration.quarantine_logging
+        RSpec.configuration.reporter.message(Quarantine::RSpecAdapter.quarantine.summary) if RSpec.configuration.quarantine_logging
       end
     end
   end

--- a/lib/quarantine/rspec_adapter.rb
+++ b/lib/quarantine/rspec_adapter.rb
@@ -1,94 +1,98 @@
-module Quarantine::RSpecAdapter
-  # Purpose: create an instance of Quarantine which contains information
-  #          about the test suite (ie. quarantined tests) and binds RSpec configurations
-  #          and hooks onto the global RSpec class
-  def self.bind_rspec
-    bind_rspec_configurations
-    bind_quarantine_list
-    bind_quarantine_checker
-    bind_quarantine_record_tests
-    bind_logger
-  end
-
-  def self.quarantine
-    @quarantine ||= Quarantine.new(
-      database: RSpec.configuration.quarantine_database,
-      list_table: RSpec.configuration.quarantine_list_table,
-      failed_tests_table: RSpec.configuration.quarantine_failed_tests_table,
-    )
-  end
-
-  private
-
-  # Purpose: binds rspec configuration variables
-  def self.bind_rspec_configurations
-    ::RSpec.configure do |config|
-      config.add_setting(:quarantine_database, default: {type: :dynamodb, region: 'us-west-1'})
-      config.add_setting(:quarantine_list_table, { default: 'quarantine_list' })
-      config.add_setting(:quarantine_failed_tests_table, { default: 'master_failed_tests' })
-      config.add_setting(:skip_quarantined_tests, { default: true })
-      config.add_setting(:quarantine_record_failed_tests, { default: true })
-      config.add_setting(:quarantine_record_flaky_tests, { default: true })
-      config.add_setting(:quarantine_logging, { default: true })
+module Quarantine
+  module RSpecAdapter
+    # Purpose: create an instance of Quarantine which contains information
+    #          about the test suite (ie. quarantined tests) and binds RSpec configurations
+    #          and hooks onto the global RSpec class
+    def self.bind_rspec
+      bind_rspec_configurations
+      bind_quarantine_list
+      bind_quarantine_checker
+      bind_quarantine_record_tests
+      bind_logger
     end
-  end
 
-  # Purpose: binds quarantine to fetch the quarantine_list from dynamodb in the before suite
-  def self.bind_quarantine_list
-    ::RSpec.configure do |config|
-      config.before(:suite) do
-        Quarantine::RSpecAdapter.quarantine.fetch_quarantine_list
+    def self.quarantine
+      @quarantine ||= Quarantine.new(
+        database: RSpec.configuration.quarantine_database,
+        list_table: RSpec.configuration.quarantine_list_table,
+        failed_tests_table: RSpec.configuration.quarantine_failed_tests_table
+      )
+    end
+
+    # Purpose: binds rspec configuration variables
+    def self.bind_rspec_configurations
+      ::RSpec.configure do |config|
+        config.add_setting(:quarantine_database, default: { type: :dynamodb, region: 'us-west-1' })
+        config.add_setting(:quarantine_list_table, { default: 'quarantine_list' })
+        config.add_setting(:quarantine_failed_tests_table, { default: 'master_failed_tests' })
+        config.add_setting(:skip_quarantined_tests, { default: true })
+        config.add_setting(:quarantine_record_failed_tests, { default: true })
+        config.add_setting(:quarantine_record_flaky_tests, { default: true })
+        config.add_setting(:quarantine_logging, { default: true })
       end
     end
-  end
 
-  # Purpose: binds quarantine to skip and pass tests that have been quarantined in the after suite
-  def self.bind_quarantine_checker
-    ::RSpec.configure do |config|
-      config.after(:each) do |example|
-        if RSpec.configuration.skip_quarantined_tests && Quarantine::RSpecAdapter.quarantine.test_quarantined?(example)
-          Quarantine::RSpecAdapter.quarantine.pass_flaky_test(example)
+    # Purpose: binds quarantine to fetch the quarantine_list from dynamodb in the before suite
+    def self.bind_quarantine_list
+      ::RSpec.configure do |config|
+        config.before(:suite) do
+          Quarantine::RSpecAdapter.quarantine.fetch_quarantine_list
         end
       end
     end
-  end
 
-  # Purpose: binds quarantine to record failed and flaky tests
-  def self.bind_quarantine_record_tests
-    ::RSpec.configure do |config|
-      config.after(:each) do |example|
-        metadata = example.metadata
-
-        # will record the failed test if is not quarantined and it is on it's final retry from the rspec-retry gem
-        Quarantine::RSpecAdapter.quarantine.record_failed_test(example) if
-          RSpec.configuration.quarantine_record_failed_tests &&
-          !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
-          metadata[:retry_attempts] + 1 == metadata[:retry] && example.exception
-
-        # will record the flaky test if is not quarantined and it failed the first run but passed a subsequent run;
-        # optionally, the upstream RSpec configuration could define an after hook that marks an example as flaky in
-        # the example's metadata
-        Quarantine::RSpecAdapter.quarantine.record_flaky_test(example) if
-          RSpec.configuration.quarantine_record_flaky_tests &&
-          !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
-          (metadata[:retry_attempts] > 0 && example.exception.nil?) || metadata[:flaky]
+    # Purpose: binds quarantine to skip and pass tests that have been quarantined in the after suite
+    def self.bind_quarantine_checker
+      ::RSpec.configure do |config|
+        config.after(:each) do |example|
+          if RSpec.configuration.skip_quarantined_tests && Quarantine::RSpecAdapter.quarantine.test_quarantined?(example)
+            Quarantine::RSpecAdapter.quarantine.pass_flaky_test(example)
+          end
+        end
       end
     end
 
-    ::RSpec.configure do |config|
-      config.after(:suite) do
-        Quarantine::RSpecAdapter.quarantine.upload_tests(:failed) if RSpec.configuration.quarantine_record_failed_tests
+    # Purpose: binds quarantine to record failed and flaky tests
+    def self.bind_quarantine_record_tests
+      ::RSpec.configure do |config|
+        config.after(:each) do |example|
+          metadata = example.metadata
 
-        Quarantine::RSpecAdapter.quarantine.upload_tests(:flaky) if RSpec.configuration.quarantine_record_flaky_tests
+          # will record the failed test if is not quarantined and it is on it's final retry from the rspec-retry gem
+          Quarantine::RSpecAdapter.quarantine.record_failed_test(example) if
+            RSpec.configuration.quarantine_record_failed_tests &&
+            !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
+            metadata[:retry_attempts] + 1 == metadata[:retry] && example.exception
+
+          # will record the flaky test if is not quarantined and it failed the first run but passed a subsequent run;
+          # optionally, the upstream RSpec configuration could define an after hook that marks an example as flaky in
+          # the example's metadata
+          Quarantine::RSpecAdapter.quarantine.record_flaky_test(example) if
+            RSpec.configuration.quarantine_record_flaky_tests &&
+            !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
+            (metadata[:retry_attempts] > 0 && example.exception.nil?) || metadata[:flaky]
+        end
+      end
+
+      ::RSpec.configure do |config|
+        config.after(:suite) do
+          if RSpec.configuration.quarantine_record_failed_tests
+            Quarantine::RSpecAdapter.quarantine.upload_tests(:failed)
+          end
+
+          Quarantine::RSpecAdapter.quarantine.upload_tests(:flaky) if RSpec.configuration.quarantine_record_flaky_tests
+        end
       end
     end
-  end
 
-  # Purpose: binds quarantine logger to output test to RSpec formatter messages
-  def self.bind_logger
-    ::RSpec.configure do |config|
-      config.after(:suite) do
-        RSpec.configuration.reporter.message(Quarantine::RSpecAdapter.quarantine.summary) if RSpec.configuration.quarantine_logging
+    # Purpose: binds quarantine logger to output test to RSpec formatter messages
+    def self.bind_logger
+      ::RSpec.configure do |config|
+        config.after(:suite) do
+          if RSpec.configuration.quarantine_logging
+            RSpec.configuration.reporter.message(Quarantine::RSpecAdapter.quarantine.summary)
+          end
+        end
       end
     end
   end

--- a/spec/quarantine/cli_spec.rb
+++ b/spec/quarantine/cli_spec.rb
@@ -24,7 +24,7 @@ describe Quarantine::CLI do
       ARGV << '-r' << 'us-west-1'
       cli.parse
 
-      expect(cli.options[:aws_region]).to eq('us-west-1')
+      expect(cli.options[:region]).to eq('us-west-1')
     end
 
     it 'define quarantined test table name' do
@@ -48,7 +48,7 @@ describe Quarantine::CLI do
     end
 
     context '#create_tables' do
-      let(:dynamodb) { Quarantine::Databases::DynamoDB.new }
+      let(:dynamodb) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1') }
       let(:cli) { Quarantine::CLI.new }
 
       it 'called with the correct arguments' do

--- a/spec/quarantine/databases/dynamo_db_spec.rb
+++ b/spec/quarantine/databases/dynamo_db_spec.rb
@@ -1,31 +1,6 @@
 require 'spec_helper'
 
 describe Quarantine::Databases::DynamoDB do
-  context '#initialize' do
-    it ' all instance variables to the default value' do
-      database = Quarantine::Databases::DynamoDB.new(additional_arg: 'foo')
-
-      expect(database.dynamodb).to be_a(Aws::DynamoDB::Client)
-      expect(database.dynamodb.config.region).to eq('us-west-1')
-    end
-
-    it 'aws region to us-east-2' do
-      database = Quarantine::Databases::DynamoDB.new(aws_region: 'us-east-2')
-
-      expect(database.dynamodb).to be_a(Aws::DynamoDB::Client)
-      expect(database.dynamodb.config.region).to eq('us-east-2')
-    end
-
-    it 'aws credentials to fake credentials' do
-      fake_creds = Aws::Credentials.new('fake', 'creds')
-      database = Quarantine::Databases::DynamoDB.new(aws_credentials: fake_creds)
-
-      expect(database.dynamodb).to be_a(Aws::DynamoDB::Client)
-      expect(database.dynamodb.config.region).to eq('us-west-1')
-      expect(database.dynamodb.config.credentials).to eq(fake_creds)
-    end
-  end
-
   context '#scan' do
     test1 = {
       'full_description' => 'quarantined_test_1',
@@ -43,7 +18,7 @@ describe Quarantine::Databases::DynamoDB do
 
     let(:dynamodb) { Aws::DynamoDB::Client.new(stub_responses: true) }
     let(:stub_multiple_tests) { dynamodb.stub_data(:scan, items: [test1, test2]) }
-    let(:database) { Quarantine::Databases::DynamoDB.new }
+    let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1') }
 
     before(:each) do
       database.dynamodb = dynamodb
@@ -81,7 +56,7 @@ describe Quarantine::Databases::DynamoDB do
     item1 = Quarantine::Test.new('1', 'quarantined_test_1', 'line 1', '123')
     item2 = Quarantine::Test.new('2', 'quarantined_test_2', 'line 2', '-1')
 
-    let(:database) { Quarantine::Databases::DynamoDB.new }
+    let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1') }
     let(:items) { [item1, item2] }
     let(:additional_attributes) { { a: 'a', b: 'b' } }
     let(:dedup_keys) { %w[id location full_description] }
@@ -150,7 +125,7 @@ describe Quarantine::Databases::DynamoDB do
   end
 
   context '#delete_item' do
-    let(:database) { Quarantine::Databases::DynamoDB.new }
+    let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1') }
 
     it 'has arguments splatted correctly' do
       result = {
@@ -170,7 +145,7 @@ describe Quarantine::Databases::DynamoDB do
   end
 
   context '#create_table' do
-    let(:database) { Quarantine::Databases::DynamoDB.new }
+    let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1') }
 
     it 'has arguments mapped and splatterd correctly' do
       attributes = [

--- a/spec/quarantine_spec.rb
+++ b/spec/quarantine_spec.rb
@@ -5,9 +5,11 @@ describe Quarantine do
     Quarantine.bind_rspec
   end
 
-  let(:options) { {
-    database: {type: :dynamodb, region: 'us-west-1'},
-  } }
+  let(:options) do
+    {
+      database: { type: :dynamodb, region: 'us-west-1' }
+    }
+  end
 
   context '#fetch_quarantine_list' do
     test1 = {


### PR DESCRIPTION
This makes it much easier to mock out in tests: all (or most) RSpec-specific logic is now isolated
to the RSpecAdapter module. Also simplifies DynamoDB configuration.