### PR TITLE
Remove CI pipeline-specific functionality, add extra_attributes setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Quarantine provides a run-time solution to diagnosing and disabling flaky tests 
 The quarantine gem supports testing frameworks:
 - [RSpec](http://rspec.info/)
 
-The quarantine gem supports CI pipelines:
-- [Buildkite](https://buildkite.com/docs/tutorials/getting-started)
+The quarantine gem supports any CI pipeline.
 
 If you are interested in using quarantine but it does not support your CI or testing framework, feel free to reach out or create an issue and we can try to make it happen.
 
@@ -110,8 +109,18 @@ end
 
 - Outputting quarantined gem info `:quarantine_logging, default: true`
 
+- Storing custom per-example attributes in the table `:quarantine_extra_attributes, default: ->(example) { {} }`
+
 ---
 ## Setup Jira Workflow
+
+```rb
+RSpec.configure do |config|
+  # Store Buildkite build number alongside test in database tables
+  config.extra_attributes = ->(example) { {
+    build_number: ENV['BUILDKITE_BUILD_NUMBER'] || '-1',
+  } }
+```
 
 To automatically create Jira tickets, take a look at: `examples/create_tickets.rb`
 

--- a/examples/create_tickets.rb
+++ b/examples/create_tickets.rb
@@ -42,7 +42,7 @@ tests.each do |test|
                          table_name: 'quarantine_list',
                          key: {
                            id: test['id'],
-                           build_number: test['build_number']
+                           build_number: test['extra_attributes']['build_number']
                          },
                          update_expression: 'jira_key = :jira_key',
                          expression_attribute_values: {

--- a/examples/unquarantine.rb
+++ b/examples/unquarantine.rb
@@ -33,7 +33,7 @@ class JiraController < ApplicationController
           { table_name: 'quarantine_list',
             key: {
               id: quarantined_test['id'],
-              build_number: quarantined_test['build_number']
+              build_number: quarantined_test['extra_attributes']['build_number']
             } }
         )
       end

--- a/lib/quarantine.rb
+++ b/lib/quarantine.rb
@@ -20,11 +20,10 @@ end
 
 class Quarantine
   attr_reader :options
-  attr_reader :quarantine_map
+  attr_reader :quarantined_ids
   attr_reader :failed_tests
   attr_reader :flaky_tests
   attr_reader :duplicate_tests
-  attr_reader :buildkite_build_number
   attr_reader :summary
 
   def self.bind_rspec
@@ -33,10 +32,9 @@ class Quarantine
 
   def initialize(options)
     @options = options
-    @quarantine_map = {}
+    @quarantined_ids = []
     @failed_tests = []
     @flaky_tests = []
-    @buildkite_build_number = ENV['BUILDKITE_BUILD_NUMBER'] || '-1'
     @summary = { id: 'quarantine', quarantined_tests: [], flaky_tests: [], database_failures: [] }
   end
 
@@ -51,7 +49,7 @@ class Quarantine
     end
   end
 
-  # Scans the quarantine_list from the database and store the individual tests in quarantine_map
+  # Scans the quarantine_list from the database and store their IDs in quarantined_ids
   def fetch_quarantine_list
     begin
       quarantine_list = database.scan(options[:list_table])
@@ -65,19 +63,7 @@ class Quarantine
       )
     end
 
-    quarantine_list.each do |example|
-      # on the rare occassion there are duplicate tests ids in the quarantine_list,
-      # quarantine the most recent instance of the test (det. through build_number)
-      # and ignore the older instance of the test
-      next if
-        quarantine_map.key?(example['id']) &&
-        example['build_number'].to_i < quarantine_map[example['id']].build_number.to_i
-
-      quarantine_map.store(
-        example['id'],
-        Quarantine::Test.new(example['id'], example['full_description'], example['location'], example['build_number'])
-      )
-    end
+    @quarantined_ids = quarantine_list.map{|q| q['id']}
   end
 
   # Based off the type, upload a list of tests to a particular database table
@@ -102,7 +88,6 @@ class Quarantine
         table_name,
         tests,
         {
-          build_job_id: ENV['BUILDKITE_JOB_ID'] || '-1',
           created_at: timestamp,
           updated_at: timestamp
         }
@@ -112,26 +97,25 @@ class Quarantine
     end
   end
 
+  def create_test(example)
+    extra_attributes = if options[:extra_attributes]
+      options[:extra_attributes].call(example)
+    else
+      {}
+    end
+    Quarantine::Test.new(example.id, example.full_description, example.location, extra_attributes)
+  end
+
   # Param: RSpec::Core::Example
   # Add the example to the internal failed tests list
   def record_failed_test(example)
-    failed_tests << Quarantine::Test.new(
-      example.id,
-      example.full_description,
-      example.location,
-      buildkite_build_number
-    )
+    failed_tests << create_test(example)
   end
 
   # Param: RSpec::Core::Example
   # Add the example to the internal flaky tests list
   def record_flaky_test(example)
-    flaky_test = Quarantine::Test.new(
-      example.id,
-      example.full_description,
-      example.location,
-      buildkite_build_number
-    )
+    flaky_test = create_test(example)
 
     flaky_tests << flaky_test
     add_to_summary(:flaky_tests, flaky_test.id)
@@ -145,9 +129,9 @@ class Quarantine
   end
 
   # Param: RSpec::Core::Example
-  # Check the internal quarantine_map to see if this test should be quarantined
+  # Check the internal quarantined_ids to see if this test should be quarantined
   def test_quarantined?(example)
-    quarantine_map.key?(example.id)
+    quarantined_ids.include?(example.id)
   end
 
   # Param: Symbol, Any

--- a/lib/quarantine/cli.rb
+++ b/lib/quarantine/cli.rb
@@ -59,7 +59,6 @@ class Quarantine
 
       attributes = [
         { attribute_name: 'id', attribute_type: 'S', key_type: 'HASH' },
-        { attribute_name: 'build_number', attribute_type: 'S', key_type: 'RANGE' }
       ]
 
       additional_arguments = {

--- a/lib/quarantine/databases/dynamo_db.rb
+++ b/lib/quarantine/databases/dynamo_db.rb
@@ -24,14 +24,12 @@ class Quarantine
       def batch_write_item(table_name, items, additional_attributes = {}, dedup_keys = %w[id full_description])
         return if items.empty?
 
-        # item_a is a duplicate of item_b if all values for each dedup_key in both item_a and item_b match
-        is_a_duplicate = ->(item_a, item_b) { dedup_keys.all? { |key| item_a[key] == item_b[key] } }
-
         scanned_items = scan(table_name)
 
         deduped_items = items.reject do |item|
+          item_hash = item.to_hash
           scanned_items.any? do |scanned_item|
-            is_a_duplicate.call(item.to_string_hash, scanned_item)
+            dedup_keys.all? { |key| item_hash[key.to_sym] == scanned_item[key] }
           end
         end
 

--- a/lib/quarantine/rspec_adapter.rb
+++ b/lib/quarantine/rspec_adapter.rb
@@ -15,6 +15,7 @@ module Quarantine::RSpecAdapter
       database: RSpec.configuration.quarantine_database,
       list_table: RSpec.configuration.quarantine_list_table,
       failed_tests_table: RSpec.configuration.quarantine_failed_tests_table,
+      extra_attributes: RSpec.configuration.quarantine_extra_attributes,
     )
   end
 
@@ -30,6 +31,7 @@ module Quarantine::RSpecAdapter
       config.add_setting(:quarantine_record_failed_tests, { default: true })
       config.add_setting(:quarantine_record_flaky_tests, { default: true })
       config.add_setting(:quarantine_logging, { default: true })
+      config.add_setting(:quarantine_extra_attributes)
     end
   end
 

--- a/lib/quarantine/test.rb
+++ b/lib/quarantine/test.rb
@@ -3,13 +3,13 @@ class Quarantine
     attr_accessor :id
     attr_accessor :full_description
     attr_accessor :location
-    attr_accessor :build_number
+    attr_accessor :extra_attributes
 
-    def initialize(id, full_description, location, build_number)
+    def initialize(id, full_description, location, extra_attributes)
       @id = id
       @full_description = full_description
       @location = location
-      @build_number = build_number
+      @extra_attributes = extra_attributes
     end
 
     def to_hash
@@ -17,16 +17,7 @@ class Quarantine
         id: id,
         full_description: full_description,
         location: location,
-        build_number: build_number
-      }
-    end
-
-    def to_string_hash
-      {
-        'id' => id,
-        'full_description' => full_description,
-        'location' => location,
-        'build_number' => build_number
+        extra_attributes: extra_attributes
       }
     end
   end

--- a/spec/quarantine/cli_spec.rb
+++ b/spec/quarantine/cli_spec.rb
@@ -54,7 +54,6 @@ describe Quarantine::CLI do
       it 'called with the correct arguments' do
         attributes = [
           { attribute_name: 'id', attribute_type: 'S', key_type: 'HASH' },
-          { attribute_name: 'build_number', attribute_type: 'S', key_type: 'RANGE' }
         ]
 
         additional_arguments = {

--- a/spec/quarantine/databases/dynamo_db_spec.rb
+++ b/spec/quarantine/databases/dynamo_db_spec.rb
@@ -6,14 +6,14 @@ describe Quarantine::Databases::DynamoDB do
       'full_description' => 'quarantined_test_1',
       'id' => '1',
       'location' => 'line 1',
-      'build_number' => '123'
+      'extra_attributes' => {'build_number' => '123'},
     }
 
     test2 = {
       'full_description' => 'quarantined_test_2',
       'id' => '2',
       'location' => 'line 2',
-      'build_number' => '-1'
+      'extra_attributes' => {'build_number' => '-1'},
     }
 
     let(:dynamodb) { Aws::DynamoDB::Client.new(stub_responses: true) }
@@ -37,12 +37,12 @@ describe Quarantine::Databases::DynamoDB do
       expect(items[0]['id']).to eq('1')
       expect(items[0]['full_description']).to eq('quarantined_test_1')
       expect(items[0]['location']).to eq('line 1')
-      expect(items[0]['build_number']).to eq('123')
+      expect(items[0]['extra_attributes']).to eq('build_number' => '123')
 
       expect(items[1]['id']).to eq('2')
       expect(items[1]['full_description']).to eq('quarantined_test_2')
       expect(items[1]['location']).to eq('line 2')
-      expect(items[1]['build_number']).to eq('-1')
+      expect(items[1]['extra_attributes']).to eq('build_number' => '-1')
     end
 
     it 'throws exception Quarantine::DatabaseError on AWS errors' do
@@ -59,7 +59,6 @@ describe Quarantine::Databases::DynamoDB do
     let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1') }
     let(:items) { [item1, item2] }
     let(:additional_attributes) { { a: 'a', b: 'b' } }
-    let(:dedup_keys) { %w[id location full_description] }
 
     it 'has arguments splatted correctly' do
       result = {
@@ -103,20 +102,18 @@ describe Quarantine::Databases::DynamoDB do
         }
       }
 
-      scanned_hash = item2.to_string_hash
-      scanned_hash['build_number'] = rand(10).to_s
       allow(database).to receive(:scan).and_return([
-                                                     scanned_hash
+                                                     {'id' => '2', 'full_description' => 'quarantined_test_2'}
                                                    ])
 
       expect(database.dynamodb).to receive(:batch_write_item).with(result).once
 
-      database.batch_write_item('foo', items, additional_attributes, dedup_keys)
+      database.batch_write_item('foo', items, additional_attributes)
     end
 
     it 'throws exception Quarantine::DatabaseError on AWS errors' do
       items = [
-        Quarantine::Test.new('some_id', 'some description', 'some location', 'some build_number')
+        Quarantine::Test.new('some_id', 'some description', 'some location', {build_number: 'some build_number'})
       ]
       error = Aws::DynamoDB::Errors::LimitExceededException.new(Quarantine, 'limit exceeded')
       allow(database.dynamodb).to receive(:scan).and_raise(error)
@@ -130,11 +127,11 @@ describe Quarantine::Databases::DynamoDB do
     it 'has arguments splatted correctly' do
       result = {
         table_name: 'foo',
-        key: { id: '1', build_number: '123' }
+        key: { id: '1' }
       }
       expect(database.dynamodb).to receive(:delete_item).with(result)
 
-      database.delete_item('foo', id: '1', build_number: '123')
+      database.delete_item('foo', id: '1')
     end
 
     it 'throws exception Quarantine::DatabaseError on AWS errors' do

--- a/spec/quarantine/test_spec.rb
+++ b/spec/quarantine/test_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 describe Quarantine::Test do
   context '#initialize' do
     it 'all instance variables to argument values' do
-      test = Quarantine::Test.new('id', 'full_description', 'location', 'build_number')
+      test = Quarantine::Test.new('id', 'full_description', 'location', {attr: 'value'})
       expect(test.id).to eq('id')
       expect(test.full_description).to eq('full_description')
       expect(test.location).to eq('location')
-      expect(test.build_number).to eq('build_number')
+      expect(test.extra_attributes).to eq(attr: 'value')
     end
   end
 
   context '#to_hash' do
     it 'returns a hash of the Quarantine::Test object' do
-      test = Quarantine::Test.new('id', 'full_description', 'location', 'build_number')
+      test = Quarantine::Test.new('id', 'full_description', 'location', {attr: 'value'})
       result = {
         id: 'id',
         full_description: 'full_description',
         location: 'location',
-        build_number: 'build_number'
+        extra_attributes: {attr: 'value'}
       }
       expect(test.to_hash).to eq(result)
     end

--- a/spec/quarantine_spec.rb
+++ b/spec/quarantine_spec.rb
@@ -5,8 +5,13 @@ describe Quarantine do
     Quarantine.bind_rspec
   end
 
+  let(:database_options) { {
+    type: :dynamodb,
+    region: 'us-west-1',
+  } }
+
   let(:options) { {
-    database: {type: :dynamodb, region: 'us-west-1'},
+    database: database_options,
   } }
 
   context '#fetch_quarantine_list' do
@@ -14,71 +19,26 @@ describe Quarantine do
       'full_description' => 'quarantined_test_1',
       'id' => '1',
       'location' => 'line 1',
-      'build_number' => '123'
     }
 
     test2 = {
       'full_description' => 'quarantined_test_2',
       'id' => '2',
       'location' => 'line 2',
-      'build_number' => '-1'
-    }
-
-    test1_duplicate = {
-      'full_description' => 'quarantined_test_1',
-      'id' => '1',
-      'location' => 'line 3',
-      'build_number' => '124'
     }
 
     let(:quarantine) { Quarantine.new(options) }
     let(:dynamodb) { Aws::DynamoDB::Client.new({ stub_responses: true }) }
     let(:stub_multiple_tests) { dynamodb.stub_data(:scan, { items: [test1, test2] }) }
-    let(:stub_duplicate_tests_replace) do
-      dynamodb.stub_data(
-        :scan,
-        { items: [
-          test1,
-          test1_duplicate
-        ] }
-      )
-    end
-    let(:stub_duplicate_tests_add) do
-      dynamodb.stub_data(
-        :scan,
-        { items: [
-          test1_duplicate,
-          test1
-        ] }
-      )
-    end
 
     it 'correctly stores quarantined tests pulled from DynamoDB' do
       allow(quarantine.database).to receive(:scan).and_return(stub_multiple_tests.items)
 
       quarantine.fetch_quarantine_list
 
-      expect(quarantine.quarantine_map.size).to eq(2)
-      expect(quarantine.quarantine_map.key?('1')).to eq(true)
-      expect(quarantine.quarantine_map.key?('2')).to eq(true)
-    end
-
-    it 'if duplicate test ids and the quarantine_map test is older, replace it with the newer test' do
-      allow(quarantine.database).to receive(:scan).and_return(stub_duplicate_tests_replace.items)
-      quarantine.fetch_quarantine_list
-
-      expect(quarantine.quarantine_map.size).to eq(1)
-      expect(quarantine.quarantine_map.key?('1')).to eq(true)
-      expect(quarantine.quarantine_map['1'].build_number).to eq('124')
-    end
-
-    it 'if duplicate test ids and the quarantine_map test is newer, add the older test to duplicate_tests' do
-      allow(quarantine.database).to receive(:scan).and_return(stub_duplicate_tests_add.items)
-      quarantine.fetch_quarantine_list
-
-      expect(quarantine.quarantine_map.size).to eq(1)
-      expect(quarantine.quarantine_map.key?('1')).to eq(true)
-      expect(quarantine.quarantine_map['1'].build_number).to eq('124')
+      expect(quarantine.quarantined_ids.size).to eq(2)
+      expect(quarantine.quarantined_ids.include?('1')).to eq(true)
+      expect(quarantine.quarantined_ids.include?('2')).to eq(true)
     end
 
     it 'if dynamodb.scan fails, make sure an exception is throw' do
@@ -104,7 +64,21 @@ describe Quarantine do
       expect(quarantine.failed_tests[0].id).to eq(example.id)
       expect(quarantine.failed_tests[0].full_description).to eq(example.full_description)
       expect(quarantine.failed_tests[0].location).to eq(example.location)
-      expect(quarantine.failed_tests[0].build_number).to eq(quarantine.buildkite_build_number)
+      expect(quarantine.failed_tests[0].extra_attributes).to eq({})
+    end
+
+    context 'with extra attributes' do
+      let(:options) { {database: database_options, extra_attributes: Proc.new { {build_number: 5} }} }
+
+      it 'adds the failed test to the @failed_test array' do |example|
+        quarantine.record_failed_test(example)
+
+        expect(quarantine.failed_tests.length).to eq(1)
+        expect(quarantine.failed_tests[0].id).to eq(example.id)
+        expect(quarantine.failed_tests[0].full_description).to eq(example.full_description)
+        expect(quarantine.failed_tests[0].location).to eq(example.location)
+        expect(quarantine.failed_tests[0].extra_attributes).to eq(build_number: 5)
+      end
     end
   end
 
@@ -118,7 +92,21 @@ describe Quarantine do
       expect(quarantine.flaky_tests[0].id).to eq(example.id)
       expect(quarantine.flaky_tests[0].full_description).to eq(example.full_description)
       expect(quarantine.flaky_tests[0].location).to eq(example.location)
-      expect(quarantine.flaky_tests[0].build_number).to eq(quarantine.buildkite_build_number)
+      expect(quarantine.flaky_tests[0].extra_attributes).to eq({})
+    end
+
+    context 'with extra attributes' do
+      let(:options) { {database: database_options, extra_attributes: Proc.new { {build_number: 5} }} }
+
+      it 'adds the flaky test to the @flaky_test array' do |example|
+        quarantine.record_flaky_test(example)
+
+        expect(quarantine.flaky_tests.length).to eq(1)
+        expect(quarantine.flaky_tests[0].id).to eq(example.id)
+        expect(quarantine.flaky_tests[0].full_description).to eq(example.full_description)
+        expect(quarantine.flaky_tests[0].location).to eq(example.location)
+        expect(quarantine.flaky_tests[0].extra_attributes).to eq(build_number: 5)
+      end
     end
   end
 
@@ -126,15 +114,7 @@ describe Quarantine do
     let(:quarantine) { Quarantine.new(options) }
 
     it 'returns true on quarantined test' do |example|
-      quarantine.quarantine_map.store(
-        example.id,
-        Quarantine::Test.new(
-          example.id,
-          example.full_description,
-          example.location,
-          '123'
-        )
-      )
+      quarantine.quarantined_ids << example.id
       expect(quarantine.test_quarantined?(example)).to eq(true)
     end
 


### PR DESCRIPTION
Depends on #22.

If the user wishes, they can capture info like build number via extra_attributes, as is now
documented in README.md. In addition to freeing us from the maintenance burden of every CI under
the sun, this provides a field for users to store data specific to their tooling.