### PR TITLE
Store all tests, including passing ones, in a single table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ Setup tables in AWS DynamoDB to support pulling and uploading quarantined tests
 bundle exec quarantine_dynamodb -h    # see all options
 
 bundle exec quarantine_dynamodb \     # create the tables in us-west-1 in aws dynamodb
-  --region us-west-1                  # with "quarantine_list" and "master_failed_tests"
-                                      # table names
+  --region us-west-1                  # with "test_statuses" table name
 ```
 
 You are all set to start quarantining tests!
@@ -87,7 +86,7 @@ Run `rspec` on the test
 CI=1 BRANCH=master rspec <filename>
 ```
 
-If the test fails and passes on the test run (rspec-retry re-ran the test), the test should be quarantined and uploaded to DynamoDB. Check the `quarantine_list` table in DynamoDB.
+If the test fails and passes on the test run (rspec-retry re-ran the test), the test should be quarantined and uploaded to DynamoDB. Check the `test_statuses` table in DynamoDB.
 
 ## Configuration
 
@@ -97,15 +96,11 @@ RSpec.configure do |config|
     config.VAR_NAME = VALUE
 end
 ```
-- Table name for quarantined tests `:quarantine_list_table, default: "quarantine_list"`
-
-- Table name where failed test are uploaded `:quarantine_failed_tests_table, default: "master_failed_tests"`
+- Table name for test statuses `:test_statuses_table, default: "test_statuses"`
 
 - Skipping quarantined tests during test runs `:skip_quarantined_tests, default: true`
 
-- Recording failed tests `:quarantine_record_failed_tests, default: true`
-
-- Recording flaky tests `:quarantine_record_flaky_tests, default: true`
+- Recording test statuses `:quarantine_record_tests, default: true`
 
 - Outputting quarantined gem info `:quarantine_logging, default: true`
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Run `rspec` on the test
 CI=1 BRANCH=master rspec <filename>
 ```
 
-If the test fails and passes on the test run (rspec-retry re-ran the test), the test should be quarantined and uploaded to DynamoDB. Check the `test_statuses` table in DynamoDB.
+All tests statuses are stored in DynamoDB. If the test fails and passes on the test run (i.e. rspec-retry re-ran the
+test), then test's status is `quarantined`. Check the `test_statuses` table in DynamoDB.
 
 ## Configuration
 

--- a/lib/quarantine/cli.rb
+++ b/lib/quarantine/cli.rb
@@ -9,8 +9,7 @@ class Quarantine
     def initialize
       # default options
       @options = {
-        quarantine_list_table_name: 'quarantine_list',
-        failed_test_table_name: 'master_failed_tests'
+        test_statuses_table_name: 'test_statuses'
       }
     end
 
@@ -26,18 +25,9 @@ class Quarantine
           '-qTABLE',
           '--quarantine_table=TABLE',
           String,
-          "Specify the table name for the quarantine list | Default: #{options[:quarantine_list_table_name]}"
+          "Specify the table name for the quarantine list | Default: #{options[:test_statuses_table_name]}"
         ) do |table_name|
-          options[:quarantine_list_table_name] = table_name
-        end
-
-        parser.on(
-          '-fTABLE',
-          '--failed_table=TABLE',
-          String,
-          "Specify the table name for the failed test list | Default: #{options[:failed_test_table_name]}"
-        ) do |table_name|
-          options[:failed_test_table_name] = table_name
+          options[:test_statuses_table_name] = table_name
         end
 
         parser.on('-h', '--help', 'Prints help page') do
@@ -69,13 +59,7 @@ class Quarantine
       }
 
       begin
-        dynamodb.create_table(options[:quarantine_list_table_name], attributes, additional_arguments)
-      rescue Quarantine::DatabaseError => e
-        warn "#{e&.cause&.class}: #{e&.cause&.message}"
-      end
-
-      begin
-        dynamodb.create_table(options[:failed_test_table_name], attributes, additional_arguments)
+        dynamodb.create_table(options[:test_statuses_table_name], attributes, additional_arguments)
       rescue Quarantine::DatabaseError => e
         warn "#{e&.cause&.class}: #{e&.cause&.message}"
       end

--- a/lib/quarantine/databases/dynamo_db.rb
+++ b/lib/quarantine/databases/dynamo_db.rb
@@ -23,23 +23,10 @@ class Quarantine
         result&.items
       end
 
-      def batch_write_item(table_name, items, additional_attributes = {}, dedup_keys = %w[id full_description])
-        return if items.empty?
-
-        scanned_items = scan(table_name)
-
-        deduped_items = items.reject do |item|
-          item_hash = item.to_hash
-          scanned_items.any? do |scanned_item|
-            dedup_keys.all? { |key| item_hash[key.to_sym] == scanned_item[key] }
-          end
-        end
-
-        return if deduped_items.empty?
-
+      def batch_write_item(table_name, items, additional_attributes = {})
         dynamodb.batch_write_item(
           request_items: {
-            table_name => deduped_items.map do |item|
+            table_name => items.map do |item|
               {
                 put_request: {
                   item: { **item.to_hash, **additional_attributes }

--- a/lib/quarantine/rspec_adapter.rb
+++ b/lib/quarantine/rspec_adapter.rb
@@ -1,99 +1,83 @@
-class Quarantine
-  module RSpecAdapter
-    # Purpose: create an instance of Quarantine which contains information
-    #          about the test suite (ie. quarantined tests) and binds RSpec configurations
-    #          and hooks onto the global RSpec class
-    def self.bind_rspec
-      bind_rspec_configurations
-      bind_quarantine_list
-      bind_quarantine_checker
-      bind_quarantine_record_tests
-      bind_logger
-    end
+module Quarantine::RSpecAdapter # rubocop:disable Style/ClassAndModuleChildren
+  # Purpose: create an instance of Quarantine which contains information
+  #          about the test suite (ie. quarantined tests) and binds RSpec configurations
+  #          and hooks onto the global RSpec class
+  def self.bind_rspec
+    bind_rspec_configurations
+    bind_fetch_test_statuses
+    bind_record_tests
+    bind_upload_tests
+    bind_logger
+  end
 
-    def self.quarantine
-      @quarantine ||= Quarantine.new(
-        database: RSpec.configuration.quarantine_database,
-        list_table: RSpec.configuration.quarantine_list_table,
-        failed_tests_table: RSpec.configuration.quarantine_failed_tests_table
-      )
-    end
+  def self.quarantine
+    @quarantine ||= Quarantine.new(
+      database: RSpec.configuration.quarantine_database,
+      test_statuses_table_name: RSpec.configuration.quarantine_test_statuses,
+      extra_attributes: RSpec.configuration.quarantine_extra_attributes
+    )
+  end
 
-    # Purpose: binds rspec configuration variables
-    def self.bind_rspec_configurations
-      ::RSpec.configure do |config|
-        config.add_setting(:quarantine_database, default: { type: :dynamodb, region: 'us-west-1' })
-        config.add_setting(:quarantine_list_table, { default: 'quarantine_list' })
-        config.add_setting(:quarantine_failed_tests_table, { default: 'master_failed_tests' })
-        config.add_setting(:skip_quarantined_tests, { default: true })
-        config.add_setting(:quarantine_record_failed_tests, { default: true })
-        config.add_setting(:quarantine_record_flaky_tests, { default: true })
-        config.add_setting(:quarantine_logging, { default: true })
-        config.add_setting(:quarantine_extra_attributes)
+  # Purpose: binds rspec configuration variables
+  def self.bind_rspec_configurations
+    ::RSpec.configure do |config|
+      config.add_setting(:quarantine_database, default: { type: :dynamodb, region: 'us-west-1' })
+      config.add_setting(:quarantine_test_statuses, { default: 'test_statuses' })
+      config.add_setting(:skip_quarantined_tests, { default: true })
+      config.add_setting(:quarantine_record_tests, { default: true })
+      config.add_setting(:quarantine_logging, { default: true })
+      config.add_setting(:quarantine_extra_attributes)
+    end
+  end
+
+  # Purpose: binds quarantine to fetch the test_statuses from dynamodb in the before suite
+  def self.bind_fetch_test_statuses
+    ::RSpec.configure do |config|
+      config.before(:suite) do
+        Quarantine::RSpecAdapter.quarantine.fetch_test_statuses
       end
     end
+  end
 
-    # Purpose: binds quarantine to fetch the quarantine_list from dynamodb in the before suite
-    def self.bind_quarantine_list
-      ::RSpec.configure do |config|
-        config.before(:suite) do
-          Quarantine::RSpecAdapter.quarantine.fetch_quarantine_list
-        end
-      end
-    end
+  # Purpose: binds quarantine to record test statuses
+  def self.bind_record_tests
+    ::RSpec.configure do |config|
+      config.after(:each) do |example|
+        metadata = example.metadata
 
-    # Purpose: binds quarantine to skip and pass tests that have been quarantined in the after suite
-    def self.bind_quarantine_checker
-      ::RSpec.configure do |config|
-        config.after(:each) do |example|
-          if RSpec.configuration.skip_quarantined_tests \
-            && Quarantine::RSpecAdapter.quarantine.test_quarantined?(example)
-            Quarantine::RSpecAdapter.quarantine.pass_flaky_test(example)
-          end
-        end
-      end
-    end
-
-    # Purpose: binds quarantine to record failed and flaky tests
-    def self.bind_quarantine_record_tests
-      ::RSpec.configure do |config|
-        config.after(:each) do |example|
-          metadata = example.metadata
-
-          # will record the failed test if is not quarantined and it is on it's final retry from the rspec-retry gem
-          Quarantine::RSpecAdapter.quarantine.record_failed_test(example) if
-            RSpec.configuration.quarantine_record_failed_tests &&
-            !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
-            metadata[:retry_attempts] + 1 == metadata[:retry] && example.exception
-
-          # will record the flaky test if is not quarantined and it failed the first run but passed a subsequent run;
+        status = :passing
+        if RSpec.configuration.skip_quarantined_tests && Quarantine::RSpecAdapter.quarantine.test_quarantined?(example)
+          Quarantine::RSpecAdapter.quarantine.pass_flaky_test(example)
+          status = :quarantined
+        elsif metadata[:retry_attempts] + 1 == metadata[:retry] && example.exception
+          # will record the failed test if it's final retry from the rspec-retry gem
+          status = :failing
+        elsif (metadata[:retry_attempts] > 0 && example.exception.nil?) || metadata[:flaky]
+          # will record the flaky test if it failed the first run but passed a subsequent run;
           # optionally, the upstream RSpec configuration could define an after hook that marks an example as flaky in
           # the example's metadata
-          Quarantine::RSpecAdapter.quarantine.record_flaky_test(example) if
-            RSpec.configuration.quarantine_record_flaky_tests &&
-            !Quarantine::RSpecAdapter.quarantine.test_quarantined?(example) &&
-            (metadata[:retry_attempts] > 0 && example.exception.nil?) || metadata[:flaky]
+          status = :quarantined
         end
-      end
 
-      ::RSpec.configure do |config|
-        config.after(:suite) do
-          if RSpec.configuration.quarantine_record_failed_tests
-            Quarantine::RSpecAdapter.quarantine.upload_tests(:failed)
-          end
-
-          Quarantine::RSpecAdapter.quarantine.upload_tests(:flaky) if RSpec.configuration.quarantine_record_flaky_tests
-        end
+        Quarantine::RSpecAdapter.quarantine.record_test(example, status)
       end
     end
+  end
 
-    # Purpose: binds quarantine logger to output test to RSpec formatter messages
-    def self.bind_logger
-      ::RSpec.configure do |config|
-        config.after(:suite) do
-          if RSpec.configuration.quarantine_logging
-            RSpec.configuration.reporter.message(Quarantine::RSpecAdapter.quarantine.summary)
-          end
+  def self.bind_upload_tests
+    ::RSpec.configure do |config|
+      config.after(:suite) do
+        Quarantine::RSpecAdapter.quarantine.upload_tests if RSpec.configuration.quarantine_record_tests
+      end
+    end
+  end
+
+  # Purpose: binds quarantine logger to output test to RSpec formatter messages
+  def self.bind_logger
+    ::RSpec.configure do |config|
+      config.after(:suite) do
+        if RSpec.configuration.quarantine_logging
+          RSpec.configuration.reporter.message(Quarantine::RSpecAdapter.quarantine.summary)
         end
       end
     end

--- a/lib/quarantine/test.rb
+++ b/lib/quarantine/test.rb
@@ -1,9 +1,10 @@
 class Quarantine
   class Test
-    attr_accessor :id, :full_description, :location, :extra_attributes
+    attr_accessor :id, :status, :full_description, :location, :extra_attributes
 
-    def initialize(id, full_description, location, extra_attributes)
+    def initialize(id, status, full_description, location, extra_attributes)
       @id = id
+      @status = status
       @full_description = full_description
       @location = location
       @extra_attributes = extra_attributes
@@ -12,6 +13,7 @@ class Quarantine
     def to_hash
       {
         id: id,
+        last_status: status,
         full_description: full_description,
         location: location,
         extra_attributes: extra_attributes

--- a/spec/quarantine/cli_spec.rb
+++ b/spec/quarantine/cli_spec.rb
@@ -6,8 +6,7 @@ describe Quarantine::CLI do
     it 'options are set with their default value' do
       cli = Quarantine::CLI.new
 
-      expect(cli.options[:quarantine_list_table_name]).to eq('quarantine_list')
-      expect(cli.options[:failed_test_table_name]).to eq('master_failed_tests')
+      expect(cli.options[:test_statuses_table_name]).to eq('test_statuses')
     end
   end
 
@@ -27,24 +26,14 @@ describe Quarantine::CLI do
       expect(cli.options[:region]).to eq('us-west-1')
     end
 
-    it 'define quarantined test table name' do
+    it 'define test statuses table name' do
       cli = Quarantine::CLI.new
 
       ARGV << '-r' << 'us-west-1'
       ARGV << '-q' << 'foo'
       cli.parse
 
-      expect(cli.options[:quarantine_list_table_name]).to eq('foo')
-    end
-
-    it 'define failed test table name' do
-      cli = Quarantine::CLI.new
-
-      ARGV << '-r' << 'us-west-1'
-      ARGV << '-f' << 'bar'
-      cli.parse
-
-      expect(cli.options[:failed_test_table_name]).to eq('bar')
+      expect(cli.options[:test_statuses_table_name]).to eq('foo')
     end
 
     context '#create_tables' do
@@ -65,13 +54,7 @@ describe Quarantine::CLI do
 
         allow(Quarantine::Databases::DynamoDB).to receive(:new).and_return(dynamodb)
         expect(dynamodb).to receive(:create_table).with(
-          'quarantine_list',
-          attributes,
-          additional_arguments
-        ).once
-
-        expect(dynamodb).to receive(:create_table).with(
-          'master_failed_tests',
+          'test_statuses',
           attributes,
           additional_arguments
         ).once

--- a/spec/quarantine/databases/dynamo_db_spec.rb
+++ b/spec/quarantine/databases/dynamo_db_spec.rb
@@ -47,7 +47,7 @@ describe Quarantine::Databases::DynamoDB do
 
     it 'throws exception Quarantine::DatabaseError on AWS errors' do
       error = Aws::DynamoDB::Errors::TableNotFoundException.new(Quarantine, 'table not found')
-      allow(database.dynamodb).to receive(:scan).and_raise(error)
+      expect(database.dynamodb).to receive(:scan).and_raise(error)
       expect { database.scan('foo') }.to raise_error(Quarantine::DatabaseError)
     end
   end
@@ -56,7 +56,7 @@ describe Quarantine::Databases::DynamoDB do
     item1 = Quarantine::Test.new('1', 'quarantined', 'quarantined_test_1', 'line 1', '123')
     item2 = Quarantine::Test.new('2', 'quarantined', 'quarantined_test_2', 'line 2', '-1')
 
-    let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1') }
+    let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1', stub_responses: true) }
     let(:items) { [item1, item2] }
     let(:additional_attributes) { { a: 'a', b: 'b' } }
 
@@ -84,7 +84,6 @@ describe Quarantine::Databases::DynamoDB do
         }
       }
 
-      allow(database).to receive(:scan).and_return([])
       expect(database.dynamodb).to receive(:batch_write_item).with(result).once
 
       database.batch_write_item('foo', items, additional_attributes)
@@ -96,7 +95,7 @@ describe Quarantine::Databases::DynamoDB do
                              { build_number: 'some build_number' })
       ]
       error = Aws::DynamoDB::Errors::LimitExceededException.new(Quarantine, 'limit exceeded')
-      allow(database.dynamodb).to receive(:scan).and_raise(error)
+      expect(database.dynamodb).to receive(:batch_write_item).and_raise(error)
       expect { database.batch_write_item('foo', items) }.to raise_error(Quarantine::DatabaseError)
     end
   end
@@ -116,7 +115,7 @@ describe Quarantine::Databases::DynamoDB do
 
     it 'throws exception Quarantine::DatabaseError on AWS errors' do
       error = Aws::DynamoDB::Errors::IndexNotFoundException.new(Quarantine, 'index not found')
-      allow(database.dynamodb).to receive(:delete_item).and_raise(error)
+      expect(database.dynamodb).to receive(:delete_item).and_raise(error)
       expect { database.delete_item('foo', id: '1') }.to raise_error(Quarantine::DatabaseError)
     end
   end
@@ -154,7 +153,7 @@ describe Quarantine::Databases::DynamoDB do
 
     it 'throws exception Quarantine::DatabaseError on AWS error' do
       error = Aws::DynamoDB::Errors::IndexNotFoundException.new(Quarantine, 'index not found')
-      allow(database.dynamodb).to receive(:create_table).and_raise(error)
+      expect(database.dynamodb).to receive(:create_table).and_raise(error)
       expect { database.create_table('foo', [], {}) }.to raise_error(Quarantine::DatabaseError)
     end
   end

--- a/spec/quarantine/test_spec.rb
+++ b/spec/quarantine/test_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe Quarantine::Test do
   context '#initialize' do
     it 'all instance variables to argument values' do
-      test = Quarantine::Test.new('id', 'full_description', 'location', { attr: 'value' })
+      test = Quarantine::Test.new('id', 'quarantined', 'full_description', 'location', { attr: 'value' })
       expect(test.id).to eq('id')
+      expect(test.status).to eq('quarantined')
       expect(test.full_description).to eq('full_description')
       expect(test.location).to eq('location')
       expect(test.extra_attributes).to eq(attr: 'value')
@@ -13,9 +14,10 @@ describe Quarantine::Test do
 
   context '#to_hash' do
     it 'returns a hash of the Quarantine::Test object' do
-      test = Quarantine::Test.new('id', 'full_description', 'location', { attr: 'value' })
+      test = Quarantine::Test.new('id', 'quarantined', 'full_description', 'location', { attr: 'value' })
       result = {
         id: 'id',
+        last_status: 'quarantined',
         full_description: 'full_description',
         location: 'location',
         extra_attributes: { attr: 'value' }

--- a/spec/quarantine_spec.rb
+++ b/spec/quarantine_spec.rb
@@ -18,17 +18,19 @@ describe Quarantine do
     }
   end
 
-  context '#fetch_quarantine_list' do
+  context '#fetch_test_statuses' do
     test1 = {
       'full_description' => 'quarantined_test_1',
       'id' => '1',
-      'location' => 'line 1'
+      'location' => 'line 1',
+      'last_status' => 'quarantined'
     }
 
     test2 = {
       'full_description' => 'quarantined_test_2',
       'id' => '2',
-      'location' => 'line 2'
+      'location' => 'line 2',
+      'last_status' => 'quarantined'
     }
 
     let(:quarantine) { Quarantine.new(options) }
@@ -38,7 +40,7 @@ describe Quarantine do
     it 'correctly stores quarantined tests pulled from DynamoDB' do
       allow(quarantine.database).to receive(:scan).and_return(stub_multiple_tests.items)
 
-      quarantine.fetch_quarantine_list
+      quarantine.fetch_test_statuses
 
       expect(quarantine.quarantined_ids.size).to eq(2)
       expect(quarantine.quarantined_ids.include?('1')).to eq(true)
@@ -49,7 +51,7 @@ describe Quarantine do
       error = Aws::DynamoDB::Errors::LimitExceededException.new(Quarantine, 'limit exceeded')
       allow(quarantine.database.dynamodb).to receive(:scan).and_raise(error)
 
-      expect { quarantine.fetch_quarantine_list }.to raise_error(Quarantine::DatabaseError)
+      expect { quarantine.fetch_test_statuses }.to raise_error(Quarantine::DatabaseError)
 
       expect(quarantine.summary[:database_failures].length).to eq(1)
       expect(quarantine.summary[:database_failures][0]).to eq(
@@ -58,58 +60,32 @@ describe Quarantine do
     end
   end
 
-  context '#record_failed_test' do
+  context '#record_test' do
     let(:quarantine) { Quarantine.new(options) }
 
-    it 'adds the failed test to the @failed_test array' do |example|
-      quarantine.record_failed_test(example)
+    it 'adds the flaky test to the @tests array' do |example|
+      quarantine.record_test(example, :quarantined)
 
-      expect(quarantine.failed_tests.length).to eq(1)
-      expect(quarantine.failed_tests[0].id).to eq(example.id)
-      expect(quarantine.failed_tests[0].full_description).to eq(example.full_description)
-      expect(quarantine.failed_tests[0].location).to eq(example.location)
-      expect(quarantine.failed_tests[0].extra_attributes).to eq({})
+      expect(quarantine.tests.length).to eq(1)
+      expect(quarantine.tests[example.id].id).to eq(example.id)
+      expect(quarantine.tests[example.id].status).to eq(:quarantined)
+      expect(quarantine.tests[example.id].full_description).to eq(example.full_description)
+      expect(quarantine.tests[example.id].location).to eq(example.location)
+      expect(quarantine.tests[example.id].extra_attributes).to eq({})
     end
 
     context 'with extra attributes' do
       let(:options) { { database: database_options, extra_attributes: proc { { build_number: 5 } } } }
 
-      it 'adds the failed test to the @failed_test array' do |example|
-        quarantine.record_failed_test(example)
+      it 'adds the flaky test to the @tests array' do |example|
+        quarantine.record_test(example, :quarantined)
 
-        expect(quarantine.failed_tests.length).to eq(1)
-        expect(quarantine.failed_tests[0].id).to eq(example.id)
-        expect(quarantine.failed_tests[0].full_description).to eq(example.full_description)
-        expect(quarantine.failed_tests[0].location).to eq(example.location)
-        expect(quarantine.failed_tests[0].extra_attributes).to eq(build_number: 5)
-      end
-    end
-  end
-
-  context '#record_flaky_test' do
-    let(:quarantine) { Quarantine.new(options) }
-
-    it 'adds the flaky test to the @flaky_test array' do |example|
-      quarantine.record_flaky_test(example)
-
-      expect(quarantine.flaky_tests.length).to eq(1)
-      expect(quarantine.flaky_tests[0].id).to eq(example.id)
-      expect(quarantine.flaky_tests[0].full_description).to eq(example.full_description)
-      expect(quarantine.flaky_tests[0].location).to eq(example.location)
-      expect(quarantine.flaky_tests[0].extra_attributes).to eq({})
-    end
-
-    context 'with extra attributes' do
-      let(:options) { { database: database_options, extra_attributes: proc { { build_number: 5 } } } }
-
-      it 'adds the flaky test to the @flaky_test array' do |example|
-        quarantine.record_flaky_test(example)
-
-        expect(quarantine.flaky_tests.length).to eq(1)
-        expect(quarantine.flaky_tests[0].id).to eq(example.id)
-        expect(quarantine.flaky_tests[0].full_description).to eq(example.full_description)
-        expect(quarantine.flaky_tests[0].location).to eq(example.location)
-        expect(quarantine.flaky_tests[0].extra_attributes).to eq(build_number: 5)
+        expect(quarantine.tests.length).to eq(1)
+        expect(quarantine.tests[example.id].id).to eq(example.id)
+        expect(quarantine.tests[example.id].status).to eq(:quarantined)
+        expect(quarantine.tests[example.id].full_description).to eq(example.full_description)
+        expect(quarantine.tests[example.id].location).to eq(example.location)
+        expect(quarantine.tests[example.id].extra_attributes).to eq(build_number: 5)
       end
     end
   end

--- a/spec/quarantine_spec.rb
+++ b/spec/quarantine_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Quarantine do
-  before(:all) do
-    Quarantine.bind_rspec
-  end
-
   let(:database_options) do
     {
       type: :dynamodb,


### PR DESCRIPTION
Depends on #23.

Add a `last_status` column with either :passing, :failing, or :quarantined values. This makes
the DB schema simpler to administer and allows other tools to manually move tests into quarantine.