### PR TITLE
Release from :quarantined to :passing state after configured number of consecutive passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ end
 
 - A failsafe limit of quarantined tests in a single run `:quarantine_failsafe_limit, default: 10`
 
+- Releasing a test from quarantine after it records enough consecutive passes `:quarantine_release_at_consecutive_passes, default: nil`
+
 ---
 ## Setup Jira Workflow
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ end
 
 - A failsafe limit of quarantined tests in a single run `:quarantine_failsafe_limit, default: 10`
 
-- Releasing a test from quarantine after it records enough consecutive passes `:quarantine_release_at_consecutive_passes, default: nil`
+- Releasing a test from quarantine after it records enough consecutive passes (`nil` to disable this feature) `:quarantine_release_at_consecutive_passes, default: nil`
 
 ---
 ## Setup Jira Workflow

--- a/lib/quarantine.rb
+++ b/lib/quarantine.rb
@@ -19,7 +19,7 @@ module RSpec
 end
 
 class Quarantine
-  attr_reader :options, :quarantined_ids, :tests
+  attr_reader :options, :old_tests, :tests
 
   def self.bind_rspec
     RSpecAdapter.bind_rspec
@@ -27,7 +27,7 @@ class Quarantine
 
   def initialize(options)
     @options = options
-    @quarantined_ids = []
+    @old_tests = {}
     @tests = {}
     @database_failures = []
   end
@@ -58,11 +58,26 @@ class Quarantine
       )
     end
 
-    @quarantined_ids = test_statuses
-                       .group_by { |t| t['id'] }
-                       .map { |_id, tests| tests.max_by { |t| t['created_at'] } }
-                       .filter { |t| t['last_status'] == 'quarantined' }
-                       .map { |t| t['id'] }
+    pairs =
+      test_statuses
+      .group_by { |t| t['id'] }
+      .map { |_id, tests| tests.max_by { |t| t['created_at'] } }
+      .filter { |t| t['last_status'] == 'quarantined' }
+      .map do |t|
+        [
+          t['id'],
+          Quarantine::Test.new(
+            t['id'],
+            t['last_status'].to_sym,
+            t['consecutive_passes'],
+            t['full_description'],
+            t['location'],
+            t['extra_attributes']
+          )
+        ]
+      end
+
+    @old_tests = Hash[pairs]
   end
 
   def upload_tests
@@ -84,27 +99,32 @@ class Quarantine
 
   # Param: RSpec::Core::Example
   # Add the example to the internal tests list
-  def record_test(example, status)
+  def record_test(example, status, passed)
     extra_attributes = if options[:extra_attributes]
                          options[:extra_attributes].call(example)
                        else
                          {}
                        end
-    test = Quarantine::Test.new(example.id, status, example.full_description, example.location, extra_attributes)
+
+    new_consecutive_passes = passed ? (old_tests[example.id]&.consecutive_passes || 0) + 1 : 0
+    release_at = options[:release_at_consecutive_passes]
+    new_status = !release_at.nil? && new_consecutive_passes >= release_at ? :passing : status
+    test = Quarantine::Test.new(
+      example.id,
+      new_status,
+      new_consecutive_passes,
+      example.full_description,
+      example.location,
+      extra_attributes
+    )
 
     tests[test.id] = test
   end
 
   # Param: RSpec::Core::Example
-  # Clear exceptions on a flaky tests that has been quarantined
-  def pass_flaky_test(example)
-    example.clear_exception!
-  end
-
-  # Param: RSpec::Core::Example
-  # Check the internal quarantined_ids to see if this test should be quarantined
+  # Check the internal old_tests to see if this test should be quarantined
   def test_quarantined?(example)
-    quarantined_ids.include?(example.id)
+    old_tests[example.id]&.status == :quarantined
   end
 
   def summary

--- a/lib/quarantine.rb
+++ b/lib/quarantine.rb
@@ -99,15 +99,11 @@ class Quarantine
 
   # Param: RSpec::Core::Example
   # Add the example to the internal tests list
-  def record_test(example, status, passed)
-    extra_attributes = if options[:extra_attributes]
-                         options[:extra_attributes].call(example)
-                       else
-                         {}
-                       end
+  def record_test(example, status, passed:)
+    extra_attributes = @options[:extra_attributes] ? @options[:extra_attributes].call(example) : {}
 
-    new_consecutive_passes = passed ? (old_tests[example.id]&.consecutive_passes || 0) + 1 : 0
-    release_at = options[:release_at_consecutive_passes]
+    new_consecutive_passes = passed ? (@old_tests[example.id]&.consecutive_passes || 0) + 1 : 0
+    release_at = @options[:release_at_consecutive_passes]
     new_status = !release_at.nil? && new_consecutive_passes >= release_at ? :passing : status
     test = Quarantine::Test.new(
       example.id,

--- a/lib/quarantine/rspec_adapter.rb
+++ b/lib/quarantine/rspec_adapter.rb
@@ -56,18 +56,18 @@ module Quarantine::RSpecAdapter # rubocop:disable Style/ClassAndModuleChildren
             # will record the failed test if it's final retry from the rspec-retry gem
             if RSpec.configuration.skip_quarantined_tests && quarantined
               example.clear_exception!
-              Quarantine::RSpecAdapter.quarantine.record_test(example, :quarantined, false)
+              Quarantine::RSpecAdapter.quarantine.record_test(example, :quarantined, passed: false)
             else
-              Quarantine::RSpecAdapter.quarantine.record_test(example, :failing, false)
+              Quarantine::RSpecAdapter.quarantine.record_test(example, :failing, passed: false)
             end
           end
         elsif metadata[:retry_attempts] > 0
           # will record the flaky test if it failed the first run but passed a subsequent run
-          Quarantine::RSpecAdapter.quarantine.record_test(example, :quarantined, false)
+          Quarantine::RSpecAdapter.quarantine.record_test(example, :quarantined, passed: false)
         elsif quarantined
-          Quarantine::RSpecAdapter.quarantine.record_test(example, :quarantined, true)
+          Quarantine::RSpecAdapter.quarantine.record_test(example, :quarantined, passed: true)
         else
-          Quarantine::RSpecAdapter.quarantine.record_test(example, :passing, true)
+          Quarantine::RSpecAdapter.quarantine.record_test(example, :passing, passed: true)
         end
       end
     end

--- a/lib/quarantine/test.rb
+++ b/lib/quarantine/test.rb
@@ -1,10 +1,11 @@
 class Quarantine
   class Test
-    attr_accessor :id, :status, :full_description, :location, :extra_attributes
+    attr_accessor :id, :status, :consecutive_passes, :full_description, :location, :extra_attributes
 
-    def initialize(id, status, full_description, location, extra_attributes)
+    def initialize(id, status, consecutive_passes, full_description, location, extra_attributes) # rubocop:disable Metrics/ParameterLists
       @id = id
       @status = status
+      @consecutive_passes = consecutive_passes
       @full_description = full_description
       @location = location
       @extra_attributes = extra_attributes
@@ -14,6 +15,7 @@ class Quarantine
       {
         id: id,
         last_status: status,
+        consecutive_passes: consecutive_passes,
         full_description: full_description,
         location: location,
         extra_attributes: extra_attributes

--- a/spec/quarantine/databases/dynamo_db_spec.rb
+++ b/spec/quarantine/databases/dynamo_db_spec.rb
@@ -53,8 +53,8 @@ describe Quarantine::Databases::DynamoDB do
   end
 
   context '#batch_write_item' do
-    item1 = Quarantine::Test.new('1', 'quarantined', 'quarantined_test_1', 'line 1', '123')
-    item2 = Quarantine::Test.new('2', 'quarantined', 'quarantined_test_2', 'line 2', '-1')
+    item1 = Quarantine::Test.new('1', 'quarantined', 1, 'quarantined_test_1', 'line 1', '123')
+    item2 = Quarantine::Test.new('2', 'quarantined', 1, 'quarantined_test_2', 'line 2', '-1')
 
     let(:database) { Quarantine::Databases::DynamoDB.new(region: 'us-west-1', stub_responses: true) }
     let(:items) { [item1, item2] }
@@ -91,7 +91,7 @@ describe Quarantine::Databases::DynamoDB do
 
     it 'throws exception Quarantine::DatabaseError on AWS errors' do
       items = [
-        Quarantine::Test.new('some_id', 'some status', 'some description', 'some location',
+        Quarantine::Test.new('some_id', 'some status', 1, 'some description', 'some location',
                              { build_number: 'some build_number' })
       ]
       error = Aws::DynamoDB::Errors::LimitExceededException.new(Quarantine, 'limit exceeded')

--- a/spec/quarantine/test_spec.rb
+++ b/spec/quarantine/test_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Quarantine::Test do
   context '#initialize' do
     it 'all instance variables to argument values' do
-      test = Quarantine::Test.new('id', 'quarantined', 'full_description', 'location', { attr: 'value' })
+      test = Quarantine::Test.new('id', 'quarantined', 1, 'full_description', 'location', { attr: 'value' })
       expect(test.id).to eq('id')
       expect(test.status).to eq('quarantined')
       expect(test.full_description).to eq('full_description')
@@ -14,10 +14,11 @@ describe Quarantine::Test do
 
   context '#to_hash' do
     it 'returns a hash of the Quarantine::Test object' do
-      test = Quarantine::Test.new('id', 'quarantined', 'full_description', 'location', { attr: 'value' })
+      test = Quarantine::Test.new('id', 'quarantined', 1, 'full_description', 'location', { attr: 'value' })
       result = {
         id: 'id',
         last_status: 'quarantined',
+        consecutive_passes: 1,
         full_description: 'full_description',
         location: 'location',
         extra_attributes: { attr: 'value' }

--- a/spec/quarantine_spec.rb
+++ b/spec/quarantine_spec.rb
@@ -66,7 +66,7 @@ describe Quarantine do
     let(:quarantine) { Quarantine.new(options) }
 
     it 'adds a new flaky test to @tests' do |example|
-      quarantine.record_test(example, :quarantined, true)
+      quarantine.record_test(example, :quarantined, passed: true)
 
       expect(quarantine.tests.length).to eq(1)
       expect(quarantine.tests[example.id].id).to eq(example.id)
@@ -78,7 +78,7 @@ describe Quarantine do
     end
 
     it 'adds a new failed test to @tests' do |example|
-      quarantine.record_test(example, :quarantined, false)
+      quarantine.record_test(example, :quarantined, passed: false)
 
       expect(quarantine.tests.length).to eq(1)
       expect(quarantine.tests[example.id].id).to eq(example.id)
@@ -96,7 +96,7 @@ describe Quarantine do
           [{ 'id' => example.id, 'last_status' => 'quarantined', 'consecutive_passes' => 5 }]
         )
 
-        quarantine.record_test(example, :quarantined, true)
+        quarantine.record_test(example, :quarantined, passed: true)
 
         expect(quarantine.tests.length).to eq(1)
         expect(quarantine.tests[example.id].id).to eq(example.id)
@@ -113,7 +113,7 @@ describe Quarantine do
             [{ 'id' => example.id, 'last_status' => 'quarantined', 'consecutive_passes' => 5 }]
           )
 
-          quarantine.record_test(example, :quarantined, true)
+          quarantine.record_test(example, :quarantined, passed: true)
 
           expect(quarantine.tests.length).to eq(1)
           expect(quarantine.tests[example.id].id).to eq(example.id)
@@ -127,7 +127,7 @@ describe Quarantine do
       let(:options) { { database: database_options, extra_attributes: proc { { build_number: 5 } } } }
 
       it 'adds a new flaky test to @tests' do |example|
-        quarantine.record_test(example, :quarantined, true)
+        quarantine.record_test(example, :quarantined, passed: true)
 
         expect(quarantine.tests.length).to eq(1)
         expect(quarantine.tests[example.id].id).to eq(example.id)
@@ -146,7 +146,7 @@ describe Quarantine do
     let(:failsafe_limit) { 10 }
 
     it 'uploads with a test' do |example|
-      quarantine.record_test(example, :quarantined, true)
+      quarantine.record_test(example, :quarantined, passed: true)
       expect(quarantine.database).to receive(:batch_write_item)
       quarantine.upload_tests
     end
@@ -160,7 +160,7 @@ describe Quarantine do
       let(:failsafe_limit) { 1 }
 
       it "doesn't upload" do |example|
-        quarantine.record_test(example, :quarantined, true)
+        quarantine.record_test(example, :quarantined, passed: true)
         expect(quarantine.database).to_not receive(:batch_write_item)
         quarantine.upload_tests
       end


### PR DESCRIPTION
Depends on #25.

This moves some useful Flexport-internal logic into the gem. Also adds a field to track the number
of passes.