### PR TITLE
Update Travis config to reflect Ruby version status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3
-  - 2.4
-  - 2.5
   - 2.6
+  - 2.7
+  - 3.0
 install:
   - rm -f Gemfile.lock
   - gem install bundler


### PR DESCRIPTION
2.3 and 2.4 have been EOL'd, 2.5 will EOL in a few days, and 3.0 has been released.

See https://www.ruby-lang.org/en/downloads/branches/