### PR TITLE
update sorbet to 0.5.10885

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.gem
 .ruby-version
+
+# vim
+*.swp
+*.swo

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ group :test do
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-sorbet', require: false
-  gem 'sorbet', '~> 0.5.6338'
+  gem 'sorbet', '~> 0.5.10885'
   gem 'tapioca', '~> 0.5.2', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quarantine (2.2.2)
+    quarantine (2.2.3)
       rspec (~> 3.0)
       rspec-retry (~> 0.6)
       sorbet-runtime (~> 0.5.6338)
@@ -140,21 +140,21 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.2)
     rexml (3.2.4)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
+      rspec-support (~> 3.12.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.10.2)
+    rspec-support (3.12.1)
     rubocop (1.6.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
@@ -178,10 +178,10 @@ GEM
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    sorbet (0.5.9297)
-      sorbet-static (= 0.5.9297)
+    sorbet (0.5.10885)
+      sorbet-static (= 0.5.10885)
     sorbet-runtime (0.5.6338)
-    sorbet-static (0.5.9297-universal-darwin-14)
+    sorbet-static (0.5.10885-universal-darwin-14)
     spoom (1.1.3)
       colorize
       sorbet (>= 0.5.6347)
@@ -226,7 +226,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-sorbet
-  sorbet (~> 0.5.6338)
+  sorbet (~> 0.5.10885)
   tapioca (~> 0.5.2)
 
 BUNDLED WITH

--- a/lib/quarantine/version.rb
+++ b/lib/quarantine/version.rb
@@ -1,3 +1,3 @@
 class Quarantine
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.2.3'.freeze
 end


### PR DESCRIPTION
Got an error with bundle install:
Could not find sorbet-static-0.5.9297-universal-darwin-14 in any of the sources

So just update to the latest version.